### PR TITLE
Control over RETRY calls through options

### DIFF
--- a/R/generator.R
+++ b/R/generator.R
@@ -311,16 +311,20 @@ doHttrRequest <- function(url,
                           customConfig=NULL,
                           simplifyVector=getOption("googleAuthR.jsonlite.simplifyVector")){
 
-  arg_list <- list(verb = request_type,
-                   url = url,
-                   config = get_google_token(shiny_access_token),
-                   body = the_body,
-                   encode = if(!is.null(customConfig$encode)) customConfig$encode else "json",
-                   add_headers("Accept-Encoding" = "gzip"),
-                   user_agent(paste0("googleAuthR/",
-                                     packageVersion("googleAuthR"),
-                                     " (gzip)"))
-                   )
+  
+  arg_list <- list(
+    verb = request_type,
+    url = url,
+    config = get_google_token(shiny_access_token),
+    body = the_body,
+    encode = if (!is.null(customConfig$encode)) customConfig$encode else "json",
+    add_headers("Accept-Encoding" = "gzip"),
+    user_agent(paste0("googleAuthR/",
+                     packageVersion("googleAuthR"),
+                     " (gzip)")),
+    times = getOption("googleAuthR.tryAttemptsHttr"),
+    terminate_on = getOption("googleAuthR.TerminateOnHttr")
+  )
 
   arg_list <- modify_custom_config(arg_list, customConfig = customConfig)
 

--- a/R/generator.R
+++ b/R/generator.R
@@ -322,8 +322,8 @@ doHttrRequest <- function(url,
     user_agent(paste0("googleAuthR/",
                      packageVersion("googleAuthR"),
                      " (gzip)")),
-    times = getOption("googleAuthR.tryAttemptsHttr"),
-    terminate_on = getOption("googleAuthR.TerminateOnHttr")
+    times = getOption("googleAuthR.HttrRetryTimes"),
+    terminate_on = getOption("googleAuthR.HttrRetryTerminateOn")
   )
 
   arg_list <- modify_custom_config(arg_list, customConfig = customConfig)

--- a/R/options.R
+++ b/R/options.R
@@ -2,15 +2,15 @@
   
   sys_or_null <- function(x){
     sys <- Sys.getenv(x)
-    if(sys == "") return(NULL)
+    if (sys == "") return(NULL)
     sys
   }
   
   scopes_split <- function(x){
     sys <- sys_or_null("GAR_SCOPES")
-    if(is.null(sys)) return(NULL)
+    if (is.null(sys)) return(NULL)
     strsplit(sys, 
-             split = ",", fixed=TRUE)[[1]]
+             split = ",", fixed = TRUE)[[1]]
   }
   op <- options()
   op.googleAuthR <- list(
@@ -25,13 +25,15 @@
     googleAuthR.scopes.selected = scopes_split("GAR_SCOPES"),
     googleAuthR.webapp.port = 1221,
     googleAuthR.jsonlite.simplifyVector = TRUE,
-    googleAuthR.ok_content_types=c("application/json; charset=UTF-8", "text/html; charset=UTF-8"),
+    googleAuthR.ok_content_types = c("application/json; charset=UTF-8", "text/html; charset=UTF-8"),
     googleAuthR.securitycode = 
-      paste0(sample(c(1:9, LETTERS, letters), 20, replace = T), collapse=''),
-    googleAuthR.tryAttempts = 5
+      paste0(sample(c(1:9, LETTERS, letters), 20, replace = T), collapse = ''),
+    googleAuthR.tryAttempts = 5,
+    googleAuthR.tryAttemptsHttr = 3,
+    googleAuthR.TerminateOnHttr = NULL
   )
   toset <- !(names(op.googleAuthR) %in% names(op))
-  if(any(toset)) options(op.googleAuthR[toset])
+  if (any(toset)) options(op.googleAuthR[toset])
   
   invisible()
   

--- a/R/options.R
+++ b/R/options.R
@@ -29,8 +29,8 @@
     googleAuthR.securitycode = 
       paste0(sample(c(1:9, LETTERS, letters), 20, replace = T), collapse = ''),
     googleAuthR.tryAttempts = 5,
-    googleAuthR.tryAttemptsHttr = 3,
-    googleAuthR.TerminateOnHttr = NULL
+    googleAuthR.HttrRetryTimes = 3,
+    googleAuthR.HttrRetryTerminateOn = NULL
   )
   toset <- !(names(op.googleAuthR) %in% names(op))
   if (any(toset)) options(op.googleAuthR[toset])


### PR DESCRIPTION
Added options to allow stopping RETRY on certain response codes and control the "times" argument.

The main motivation for this is to stop RETRY on 400 error for [DoubleClick API](https://developers.google.com/doubleclick-search/v2/how-tos/conversions/insert) which returns error for each transaction that failed in the response. Most transactions from the request are successful, so there is no point to RETRY - it is potentially dangerous as well.