### PR TITLE
Fix typo

### DIFF
--- a/vignettes/advanced-building.Rmd
+++ b/vignettes/advanced-building.Rmd
@@ -17,14 +17,14 @@ These go into more edge cases: no parsing content, batching and caching API resp
 
 In some cases you may want to skip all parsing of API content, perhaps if it is not JSON or some other reason.
 
-For this, you can use the option `option("googleAuthR.rawResponse" = TRUE)` to skip all tests and return the raw response.
+For this, you can use the option `options("googleAuthR.rawResponse" = TRUE)` to skip all tests and return the raw response.
 
 Here is an example of this from the googleCloudStorageR library:
 
 ```r
 gcs_get_object <- function(bucket, 
                            object_name){
-  ## skip JSON parsing on output as we epxect a CSV
+  ## skip JSON parsing on output as we expect a CSV
   options(googleAuthR.rawResponse = TRUE)
   
   ## do the request

--- a/vignettes/building.Rmd
+++ b/vignettes/building.Rmd
@@ -58,7 +58,7 @@ A lot of Google APIs look for you to send data in the Body of the request.  This
  
  Construct your list, then use `jsonlite::toJSON` to check if its in the correct format as specified by the Google documentation.  This is often the hardest part using the API.
  
-To aid debugging use the `option(googleAuthR.verbose = 0)` to see all the sent and recieved HTTP requests, and also write what was sent as JSON in the body is written to a file called `request_debug.rds` in the working directory.
+To aid debugging use the `options(googleAuthR.verbose = 0)` to see all the sent and recieved HTTP requests, and also write what was sent as JSON in the body is written to a file called `request_debug.rds` in the working directory.
 
 Example:
 


### PR DESCRIPTION
I'm not sure how to properly knit the Rmd file to overwrite the namesake **building.html** file. I tried this, but it didn't work as I thought it would. I figured you should know how to properly knit/export to .html. 

```
> devtools::build_vignettes()
Building googleAuthR vignettes
Moving advanced-building.html, building.html, google-authentication-types.html, setup.html, troubleshooting.html, advanced-building.R, building.R, google-authentication-types.R, setup.R, troubleshooting.R to inst/doc/
Copying advanced-building.Rmd, building.Rmd, google-authentication-types.Rmd, setup.Rmd, troubleshooting.Rmd to inst/doc/
```
* As you can see it moved to **inst/doc** folder for some reason, so there must be another way I'm assuming