### PR TITLE
Pass ellipsis from `gar_auth(...)` to `gargle::token_fetch(...)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Add `gar_scope_config` 
 * Add Docker build available at `gcr.io/gcer-public/googleauthr`
+* Pass parameters from `gar_auth(...)` to `gargle::token_fetch(...)`
 
 # googleAuthR v1.1.1
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -9,8 +9,9 @@
 #' @param app app as specified by \link{gar_auth_configure}
 #' @param package The name of the package authenticating
 #' @param cache Where to store authentication tokens
-#' @param use_oob Whther to use OOB browserless authetication
+#' @param use_oob Whether to use OOB browserless authentication
 #' @param new_user Deprecated, not used
+#' @param ... Arguments passed to \link[gargle]{token_fetch}
 #'
 #' @return an OAuth token object, specifically a
 #'   \code{\link[=Token-class]{Token2.0}}, invisibly
@@ -37,6 +38,9 @@
 #'          
 #' # ..query BigQuery functions ...
 #' 
+#' # use an existing refresh token to generate a fresh one
+#' gar_auth(credentials = list(refresh_token = "1//the-refresh-token"))
+#' 
 #' }
 #'
 #' @export
@@ -51,7 +55,8 @@ gar_auth <- function(token = NULL,
                      cache = gargle::gargle_oauth_cache(),
                      use_oob = gargle::gargle_oob_default(),
                      package = "googleAuthR",
-                     new_user = NULL) {
+                     new_user = NULL,
+                     ...) {
   
   if(!is.null(new_user)){
     warning("Argument new_user is deprecated and will be removed next release.")
@@ -92,7 +97,8 @@ gar_auth <- function(token = NULL,
     app = gar_oauth_app(),
     package = package,
     cache = cache,
-    use_oob = use_oob
+    use_oob = use_oob,
+    ...
   )
   
   if(!is.token2.0(token)){

--- a/man/gar_auth.Rd
+++ b/man/gar_auth.Rd
@@ -8,7 +8,7 @@ gar_auth(token = NULL, email = NULL,
   scopes = getOption("googleAuthR.scopes.selected"),
   app = gar_oauth_app(), cache = gargle::gargle_oauth_cache(),
   use_oob = gargle::gargle_oob_default(), package = "googleAuthR",
-  new_user = NULL)
+  new_user = NULL, ...)
 }
 \arguments{
 \item{token}{an actual token object or the path to a valid token stored as an
@@ -22,11 +22,13 @@ gar_auth(token = NULL, email = NULL,
 
 \item{cache}{Where to store authentication tokens}
 
-\item{use_oob}{Whther to use OOB browserless authetication}
+\item{use_oob}{Whether to use OOB browserless authentication}
 
 \item{package}{The name of the package authenticating}
 
 \item{new_user}{Deprecated, not used}
+
+\item{...}{Arguments passed to \link[gargle]{token_fetch}}
 }
 \value{
 an OAuth token object, specifically a
@@ -56,6 +58,9 @@ gar_auth(email = "your@email.com",
          scopes = "https://www.googleapis.com/auth/bigquery")
          
 # ..query BigQuery functions ...
+
+# use an existing refresh token to generate a fresh one
+gar_auth(credentials = list(refresh_token = "1//the-refresh-token"))
 
 }
 

--- a/tests/testthat/test-gargle.R
+++ b/tests/testthat/test-gargle.R
@@ -25,6 +25,15 @@ test_that("Auth works by specifying email", {
   expect_s3_class(token, "Gargle2.0")
 })
 
+test_that("Auth works using an existing refresh token", {
+  skip_on_cran()
+
+  credentials <- list(token = "abc", refresh_token = '1//a-b-c')
+  tt <- gar_auth(email='a@b.c', credentials = credentials)
+  
+  expect_s3_class(gar_auth(tt), "Token2.0")
+  expect_equal(tt$credentials, credentials)
+})
 
 context("gargle backward compatibility")
 


### PR DESCRIPTION
This allows to pass any parameter to any of the default functions used by `token_fetch`, for instance it works with offline refresh tokens as follows

```
gar_auth_configure(app = oauth_app("google", key = client.id, secret = client.secret))
gar_auth(credentials = list(refresh_token = "1//refresh-token-here"))
```
