### PR TITLE
Fixed `googleSignIn` documentation per #171.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Add Docker build available at `gcr.io/gcer-public/googleauthr`
 * More API error feedback if using googleAuthR.verbose < 3
 * Auto-auth should succeed if one of the scopes needed is present
+* Corrected and clarified `googleSignIn` documentation (#171, @jonthegeek).
 
 # googleAuthR v1.1.1
 

--- a/R/shiny-js-signin.R
+++ b/R/shiny-js-signin.R
@@ -45,13 +45,14 @@ googleSignInUI <- function(id, logout_name = "Sign Out", logout_class = "btn-dan
 #'
 #' Call via \code{shiny::callModule(googleSignIn, "your_id")}.
 #'
-#' @param input shiny input
-#' @param output shiny output (\code{id}, \code{name}, \code{email}, \code{image}, \code{signed_in})
+#' @param input shiny input (must contain \code{g_id}, \code{g_name},
+#'   \code{g_email}, \code{g_image}, \code{g_signed_in})
+#' @param output shiny output (passed by shiny but not used)
 #' @param session shiny session
 #'
 #' @author Based on original code by David Kulp
-#' @return A reactive list with values \code{$g_id}, \code{$g_name}, \code{$g_email}, \code{$g_image}
-#' and \code{$signed_in}.
+#' @return A reactive list with values \code{$id}, \code{$name}, \code{$email},
+#'   \code{$image} and \code{$signed_in}.
 #' @export
 googleSignIn <- function(input, output, session){
   check_package_loaded("shiny")

--- a/man/googleSignIn.Rd
+++ b/man/googleSignIn.Rd
@@ -7,15 +7,16 @@
 googleSignIn(input, output, session)
 }
 \arguments{
-\item{input}{shiny input}
+\item{input}{shiny input (must contain \code{g_id}, \code{g_name},
+\code{g_email}, \code{g_image}, \code{g_signed_in})}
 
-\item{output}{shiny output (\code{id}, \code{name}, \code{email}, \code{image}, \code{signed_in})}
+\item{output}{shiny output (passed by shiny but not used)}
 
 \item{session}{shiny session}
 }
 \value{
-A reactive list with values \code{$g_id}, \code{$g_name}, \code{$g_email}, \code{$g_image}
-and \code{$signed_in}.
+A reactive list with values \code{$id}, \code{$name}, \code{$email},
+  \code{$image} and \code{$signed_in}.
 }
 \description{
 Shiny Module for use with \link{googleSignInUI}.  


### PR DESCRIPTION
Simple documentation fix. Closes #171.