### PR TITLE
gar_auth() check conditions (#184)

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -60,7 +60,7 @@ gar_auth <- function(token = NULL,
   }
   
   # set scopes to options for backward compatibility  
-  if(!is.null(scopes) && scopes != ""){
+  if(!is.null(scopes) && any(scopes != "")){
     options(googleAuthR.scopes.selected = scopes)
   }
   

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,10 +1,10 @@
 test_that("vectorized condiction are correctly managed", {
 
   withr::local_envvar(c(`_R_CHECK_LENGTH_1_LOGIC2_` = "true"))
-  
-  old_opt <- options(googleAuthR.scopes.selected = c("foo", "bar"))
-  withr::defer(options(old_opt))
-  
+  withr::local_options(
+    list(googleAuthR.scopes.selected = c("foo", "bar"))
+  )
+
   # The original error to avoid was 
   # "'length(x) = 2 > 1' in coercion to 'logical(1)'"
   expect_error(

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,0 +1,14 @@
+test_that("vectorized condiction are correctly managed", {
+
+  withr::local_envvar(c(`_R_CHECK_LENGTH_1_LOGIC2_` = "true"))
+  
+  old_opt <- options(googleAuthR.scopes.selected = c("foo", "bar"))
+  withr::defer(options(old_opt))
+  
+  # The original error to avoid was 
+  # "'length(x) = 2 > 1' in coercion to 'logical(1)'"
+  expect_error(
+    googleAuthR::gar_auth(),
+    "Non-interactive session and no authentication email selected"
+  )
+})


### PR DESCRIPTION
In `gar_auth()` the second check look for `NULL` or empty scopes.
As highlighted in #184, the second check (ie `scopes != ""`) can be and actually is a vector of length greater than one. This could possibly lead to errors because only the first element would be considered.

This pull request purpose to solve the issue by wrapping that check into an `any()` call (ie, `any(scopes != "")`).

A test is also provided to check against this issue, all the other tests passed on my machine (Linux Debian 10, R 4.0.2, googleAuthR 1.3.0)