### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: googleAuthR
 Type: Package
-Version: 1.3.0.9000
+Version: 1.3.0.9001
 Title: Authenticate and Create Google APIs
 Description: Create R functions that interact with OAuth2 Google APIs 
     <https://developers.google.com/apis-explorer/> easily,

--- a/R/auth_gargle.R
+++ b/R/auth_gargle.R
@@ -3,15 +3,9 @@
 
 #' Environment to store authentication credentials
 #' 
-#' Used to keep persistent state.
+#' Used to keep persistent state. Initialized in .onLoad.
 #' @noRd
-.auth <- gargle::init_AuthState(
-  package = "googleAuthR",
-  auth_active = TRUE
-  #app = NULL,
-  #api_key = NULL,
-  #cred = NULL
-)
+.auth <- NULL
 
 
 ## The roxygen comments for these functions are mostly generated from data

--- a/R/options.R
+++ b/R/options.R
@@ -1,5 +1,13 @@
 .onLoad <- function(libname, pkgname) {
   
+  .auth <<- gargle::init_AuthState(
+    package = "googleAuthR",
+    auth_active = TRUE
+    #app = NULL,
+    #api_key = NULL,
+    #cred = NULL
+  )
+  
   sys_or_null <- function(x){
     sys <- Sys.getenv(x)
     if (sys == "") return(NULL)


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for r-lib/gargle#157, but is a good change even without that PR.