### PR TITLE
Added a temporary fix GCE OAuth issue

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -9,7 +9,7 @@
 #' @param app app as specified by \link{gar_auth_configure}
 #' @param package The name of the package authenticating
 #' @param cache Where to store authentication tokens
-#' @param use_oob Whther to use OOB browserless authetication
+#' @param use_oob Whether to use OOB browserless authentication
 #'
 #' @return an OAuth token object, specifically a
 #'   \code{\link[=Token-class]{Token2.0}}, invisibly

--- a/R/auth.R
+++ b/R/auth.R
@@ -79,15 +79,29 @@ gar_auth <- function(token = NULL,
     make_app()
   }
   
-  token <- token_fetch(
-    email = email,
-    token = token,
-    scopes = scopes,
-    app = gar_oauth_app(),
-    package = package,
-    cache = cache,
-    use_oob = use_oob
-  )
+  if (is.token2.0(token)) {
+    # Fix for https://github.com/r-lib/gargle/issues/187, unless
+    # gargle:::gargle_env$cred_funs is reordered
+    token = gargle::credentials_byo_oauth2(
+      email = email,
+      token = token,
+      scopes = scopes,
+      app = gar_oauth_app(),
+      package = package,
+      cache = cache,
+      use_oob = use_oob
+      )
+  } else {
+    token <- token_fetch(
+      email = email,
+      token = token,
+      scopes = scopes,
+      app = gar_oauth_app(),
+      package = package,
+      cache = cache,
+      use_oob = use_oob
+    )
+  }
   
   if(!is.token2.0(token)){
     stop("Could not authenticate via any gargle cred function", call. = FALSE)

--- a/man/gar_auth.Rd
+++ b/man/gar_auth.Rd
@@ -26,7 +26,7 @@ gar_auth(
 
 \item{cache}{Where to store authentication tokens}
 
-\item{use_oob}{Whther to use OOB browserless authetication}
+\item{use_oob}{Whether to use OOB browserless authentication}
 
 \item{package}{The name of the package authenticating}
 }


### PR DESCRIPTION
Added a temporary fix for https://github.com/r-lib/gargle/issues/187.  If you pass in a Token2.0 into `gar_auth` with the newer version of gargle it uses bring your own (byo) token.  I don't know what you're testing on and since it's got differential behavior in non-interactive auth, I'm not sure how you'd test.  I think this could potentially be a large breaking change if people's workflows implicitly relied on the `gargle` behavior, so I'm not sure if you want to incorporate or just wait for `gargle` to determine if they are going to handle this edge case.