### PR TITLE
Set the token when invoking `gar_gce_auth_default`

### DIFF
--- a/R/gce.R
+++ b/R/gce.R
@@ -39,10 +39,15 @@
 #' @seealso \href{https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token}{gcloud reference}
 gar_gce_auth_default <- function(scopes = getOption("googleAuthR.scopes.selected",
                                                     "https://www.googleapis.com/auth/cloud-platform")){
-  
-  # doesn't this need the returned access token?
-  credentials_app_default(scopes = scopes)
-  
+
+  token <- credentials_app_default(scopes = scopes)
+
+  myMessage("Authenticated with Application Default Credentials", level = 2)
+
+  .auth$set_cred(token)
+  .auth$set_auth_active(TRUE)
+
+  invisible(token)
 }
 
 


### PR DESCRIPTION
Following the same behavior as `gar_gce_auth` for the sake of consistency and because it looks like it might have been the original intention as well, judging from the function's documentation.

Now the token is not only generated, but also automatically established internally in the library to be used for subsequent API calls.

Before this commit, one would have to write:

```R
token <- gar_gce_auth_default()
gar_auth(token)
```

while now this is enough:

```R
gar_gce_auth_default()
```

which maintains symmetry to how one would authorize using GCE credentials:

```R
gar_gce_auth()
```